### PR TITLE
Update logging.yml

### DIFF
--- a/config/logging.yml
+++ b/config/logging.yml
@@ -35,7 +35,6 @@ appender:
     type: dailyRollingFile
     file: ${path.logs}/${cluster.name}.log
     datePattern: "'.'yyyy-MM-dd"
-    maxBackupIndex: 2
     layout:
       type: pattern
       conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
@@ -44,7 +43,6 @@ appender:
     type: dailyRollingFile
     file: ${path.logs}/${cluster.name}_index_search_slowlog.log
     datePattern: "'.'yyyy-MM-dd"
-    maxBackupIndex: 2
     layout:
       type: pattern
       conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
@@ -53,7 +51,6 @@ appender:
     type: dailyRollingFile
     file: ${path.logs}/${cluster.name}_index_indexing_slowlog.log
     datePattern: "'.'yyyy-MM-dd"
-    maxBackupIndex: 2
     layout:
       type: pattern
       conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"


### PR DESCRIPTION
fixing warning:
log4j:WARN No such property [maxBackupIndex] in org.apache.log4j.DailyRollingFileAppender.
log4j:WARN No such property [maxBackupIndex] in org.apache.log4j.DailyRollingFileAppender.
log4j:WARN No such property [maxBackupIndex] in org.apache.log4j.DailyRollingFileAppender.