### PR TITLE
Environment Variable references changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,4 +92,4 @@ This image can be configured by means of environment variables, that one can set
 * [HTTP_CORS_ALLOW_ORIGIN](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-http.html#_settings_2)
 * [NUMBER_OF_MASTERS](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-discovery-zen.html#master-election)
 * [MAX_LOCAL_STORAGE_NODES](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-node.html#max-local-storage-nodes)
-* [ES_JAVA_OPTS](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/heap-size.html)
+* [ES_JAVA_OPTS](https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html)

--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ I also make available special images and instructions for [AWS EC2](https://gith
 
 This image can be configured by means of environment variables, that one can set on a `Deployment`.
 
-* [CLUSTER_NAME](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-configuration.html#cluster-name)
-* [NODE_MASTER](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html#master-node)
-* [NODE_DATA](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html#data-node)
-* [NETWORK_HOST](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html#common-network-settings)
-* [HTTP_ENABLE](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#_settings_2)
-* [HTTP_CORS_ENABLE](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#_settings_2)
-* [HTTP_CORS_ALLOW_ORIGIN](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html#_settings_2)
-* [NUMBER_OF_MASTERS](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-zen.html#master-election)
-* [MAX_LOCAL_STORAGE_NODES](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html#max-local-storage-nodes)
-* [ES_JAVA_OPTS](https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html)
+* [CLUSTER_NAME](https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#cluster.name)
+* [NODE_MASTER](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-node.html#master-node)
+* [NODE_DATA](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-node.html#data-node)
+* [NETWORK_HOST](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-network.html#common-network-settings)
+* [HTTP_ENABLE](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-http.html#_settings_2)
+* [HTTP_CORS_ENABLE](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-http.html#_settings_2)
+* [HTTP_CORS_ALLOW_ORIGIN](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-http.html#_settings_2)
+* [NUMBER_OF_MASTERS](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-discovery-zen.html#master-election)
+* [MAX_LOCAL_STORAGE_NODES](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-node.html#max-local-storage-nodes)
+* [ES_JAVA_OPTS](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/heap-size.html)


### PR DESCRIPTION
from version 5 onwards, the documentation has moved.

I've updated the first link to the location of the parameter for version 5

I've updated the other links to the latest version for which the links were valid. 

Please advice what you would prefer to do