### PR TITLE
conditionally install x-pack

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -18,4 +18,7 @@ export NODE_NAME=${NODE_NAME}
 
 
 # run
+if [ "${INSTALL_XPACK}" == "true" ]; then
+	/elasticsearch/bin/elasticsearch-plugin install -s x-pack
+fi
 sudo -E -u elasticsearch /elasticsearch/bin/elasticsearch


### PR DESCRIPTION
Uses the elasticsearch-plugin installer to install x-pack based on an environment variable before running elasticsearch.