### PR TITLE
Ability to install Elasticsearch Plugins via Environment Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ docker run --name elasticsearch \
         quay.io/pires/docker-elasticsearch:5.2.2
 ```
 
+Ready to use node with plugins (x-pack and repository-gcs) pre installed. Already installed plugins are ignored:
+```
+docker run --name elasticsearch \
+	--detach \
+	--privileged \
+	--volume /path/to/data_folder:/data \
+	-e ES_JAVA_OPTS="-Xms8g -Xmx8g" \
+	-e ES_PLUGINS_INSTALL="repository-gcs,x-pack" \
+        quay.io/pires/docker-elasticsearch:5.2.2
+```
+
 **Master-only** node for cluster `elasticsearch-default`:
 ```
 docker run --name elasticsearch \
@@ -76,7 +87,6 @@ docker run --name elasticsearch \
 	-e NODE_DATA=false \
         quay.io/pires/docker-elasticsearch:5.2.2
 ```
-
 I also make available special images and instructions for [AWS EC2](https://github.com/pires/docker-elasticsearch-aws) and [Kubernetes](https://github.com/pires/docker-elasticsearch-kubernetes).
 
 ### Environment variables
@@ -94,3 +104,4 @@ This image can be configured by means of environment variables, that one can set
 * [NUMBER_OF_MASTERS](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-zen.html#master-election)
 * [MAX_LOCAL_STORAGE_NODES](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html#max-local-storage-nodes)
 * [ES_JAVA_OPTS](https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html)
+* [ES_PLUGINS_INSTALL](https://www.elastic.co/guide/en/elasticsearch/plugins/current/installation.html) - comma separated list of Elasticsearch plugins to be installed. Example: `ES_PLUGINS_INSTALL="repository-gcs,x-pack"`

--- a/run.sh
+++ b/run.sh
@@ -16,9 +16,16 @@ if [ -z "${NODE_NAME}" ]; then
 fi
 export NODE_NAME=${NODE_NAME}
 
+if [ ! -z "${ES_PLUGINS_INSTALL}" ]; then
+   OLDIFS=$IFS
+   IFS=','
+   for plugin in ${ES_PLUGINS_INSTALL}; do
+      if ! /elasticsearch/bin/elasticsearch-plugin list | grep -qs ${plugin}; then
+         yes | /elasticsearch/bin/elasticsearch-plugin install --batch ${plugin}
+      fi
+   done
+   IFS=$OLDIFS
+fi
 
 # run
-if [ "${INSTALL_XPACK}" == "true" ]; then
-	/elasticsearch/bin/elasticsearch-plugin install -s x-pack
-fi
 sudo -E -u elasticsearch /elasticsearch/bin/elasticsearch


### PR DESCRIPTION
Ability to install Elasticsearch Plugins via Environment Variable.

*  The environment variable `ES_PLUGINS_INSTALL`  holds a comma separated list of plugins to be installed. Example: `ES_PLUGINS_INSTALL="repository-gcs,x-pack"`
* Already installed plugins are ignored


```
docker run --name elasticsearch \
    --detach \
    --privileged \
    --volume /tmp:/data \
    -e ES_PLUGINS_INSTALL="repository-gcs,x-pack" \
    quay.io/pires/docker-elasticsearch:5.2.2
```
