### PR TITLE
Add sync to run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -16,6 +16,9 @@ if [ -z "${NODE_NAME}" ]; then
 fi
 export NODE_NAME=${NODE_NAME}
 
+# Prevent "Text file busy" errors
+sync
+
 if [ ! -z "${ES_PLUGINS_INSTALL}" ]; then
    OLDIFS=$IFS
    IFS=','


### PR DESCRIPTION
Without a sync I get an error about 50% of the time on GKE when trying to install plugins:

```bash
/run.sh: line 28: /elasticsearch/bin/elasticsearch-plugin: Text file busy
```

Fixes #33