### PR TITLE
Update the broken link for CLUSTER_NAME in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ I also make available special images and instructions for [AWS EC2](https://gith
 
 This image can be configured by means of environment variables, that one can set on a `Deployment`.
 
-* [CLUSTER_NAME](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-configuration.html#cluster-name)
+* [CLUSTER_NAME](https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#cluster.name)
 * [NODE_NAME](https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#node.name)
 * [NODE_MASTER](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html#master-node)
 * [NODE_DATA](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html#data-node)


### PR DESCRIPTION
The link for the 'CLUSTER_NAME' is broken. It gives 404. This small PR is to fix that