### PR TITLE
Adding K8s scripts to ensure elasticsearch has properly started

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,9 @@ COPY config /elasticsearch/config
 # Copy run script
 COPY run.sh /
 
+# Copy Kubernetes hooks
+COPY k8s /k8s
+
 # Set environment variables defaults
 ENV ES_JAVA_OPTS "-Xms512m -Xmx512m"
 ENV CLUSTER_NAME elasticsearch-default

--- a/k8s/postStart.sh
+++ b/k8s/postStart.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+while [ $(netstat -auntpl | grep LISTEN | grep -c 9300) -eq 0 ] ; do
+  echo "waiting port to be opened"
+  sleep 5
+  pidof java || exit 1
+done
+exit 0


### PR DESCRIPTION
On a rolling restart strategy in kubernetes, it doesn't ensure
elasticsearch has proprely finish to boot.
    
For example if there is a bad value in the configuration file, it will
start booting, kubernetes doesn't wait until the port is open, then
crash and finally you've got a full failed cluster because Kubernetes
will continue to rollout without checking.
    
Using a postStart hook ensure the port is open until it restarts the
next instance. The script could also be added and mounted in a configmap
but I think it's preferable to add it in the container with all other
potential useful scripts for kubernetes.
