### PR TITLE
Allow modifying elasticsearch.yml using environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ This image can be configured by means of environment variables, that one can set
 * [MEMORY_LOCK](https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#bootstrap.memory_lock) - memory locking control - enable to prevent swap (default = `true`) .
 * [REPO_LOCATIONS](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html#_shared_file_system_repository) - list of registered repository locations. For example `["/backup"]` (default = `[]`).
 * [PROCESSORS](https://github.com/elastic/elasticsearch-definitive-guide/pull/679/files) - allow elasticsearch to optimize for the actual number of available cpus (must be an integer - default = 1)
+* [ES_KEYSTORE_*](https://www.elastic.co/guide/en/elasticsearch/reference/current/secure-settings.html) - add any ES Keystore items by adding a new environment variable. Double underscore will be replaced with dots, e.g. ES_KEYSTORE_S3__CLIENT__DEFAULT__ACCESS_KEY ends up as s3.client.default.access_key
 
 ### Backup
 Mount a shared folder (for example via NFS) to `/backup` and make sure the `elasticsearch` user

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ This image can be configured by means of environment variables, that one can set
 * [MEMORY_LOCK](https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#bootstrap.memory_lock) - memory locking control - enable to prevent swap (default = `true`) .
 * [REPO_LOCATIONS](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html#_shared_file_system_repository) - list of registered repository locations. For example `["/backup"]` (default = `[]`).
 * [PROCESSORS](https://github.com/elastic/elasticsearch-definitive-guide/pull/679/files) - allow elasticsearch to optimize for the actual number of available cpus (must be an integer - default = 1)
+* ES_CONFIG_* - add any entries to elasticsearch.yml by prodiving multiple variables. Double underscore will be replaced with dots, e.g. ES_CONFIG_S3__CLIENT__MINIO__PROTOCOL='http' ends up as s3.client.minio.protocol: http
 * [ES_KEYSTORE_*](https://www.elastic.co/guide/en/elasticsearch/reference/current/secure-settings.html) - add any ES Keystore items by adding a new environment variable. Double underscore will be replaced with dots, e.g. ES_KEYSTORE_S3__CLIENT__DEFAULT__ACCESS_KEY ends up as s3.client.default.access_key
 
 ### Backup

--- a/run.sh
+++ b/run.sh
@@ -40,6 +40,14 @@ if [ ! -z "${SHARD_ALLOCATION_AWARENESS_ATTR}" ]; then
     fi
 fi
 
+for item in ${!ES_CONFIG_*}; do
+    value=${!item}
+    item=${item##ES_CONFIG_}   # Strip away prefix
+    item=${item,,}             # Lowercase
+    item=${item//__/.}         # Replace double underscore with dot
+    echo "${item}: ${value}" >> $BASE/config/elasticsearch.yml
+done
+
 # run
 chown -R elasticsearch:elasticsearch $BASE
 

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 BASE=/elasticsearch
 
@@ -42,5 +42,18 @@ fi
 
 # run
 chown -R elasticsearch:elasticsearch $BASE
+
+for item in ${!ES_KEYSTORE_*}; do
+    value=${!item}
+    item=${item##ES_KEYSTORE_} # Strip away prefix
+    item=${item,,}             # Lowercase
+    item=${item//__/.}         # Replace double underscore with dot
+
+    if [ ! -f  $BASE/config/elasticsearch.keystore ]; then
+        su-exec elasticsearch $BASE/bin/elasticsearch-keystore create
+    fi
+    su-exec elasticsearch $BASE/bin/elasticsearch-keystore add -x $item <<< ${value}
+done
+
 chown -R elasticsearch:elasticsearch /data
 exec su-exec elasticsearch $BASE/bin/elasticsearch


### PR DESCRIPTION
To add any additional configuration to elasticsearch.yml, you can use environment variables ES_CONFIG_*. As already done for elasticsearch-keystore, all variables starting with ES_CONFIG_ get evaluated and will be placed in elasticsearch.yml before starting ES.

This PR needs to get #50 to get merged first to avoid merge conflicts.