### PR TITLE
Fixed directory ownership handling and allowed node awareness to be read from an env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,15 +28,8 @@ RUN apk add --no-cache -t .build-deps gnupg openssl \
   && ls -lah \
   && mv elasticsearch-$ES_VERSION /elasticsearch \
   && adduser -DH -s /sbin/nologin elasticsearch \
-  && echo "===> Creating Elasticsearch Paths..." \
-  && for path in \
-  	/elasticsearch/config \
-  	/elasticsearch/config/scripts \
-  	/elasticsearch/plugins \
-  ; do \
-  mkdir -p "$path"; \
-  chown -R elasticsearch:elasticsearch "$path"; \
-  done \
+  && mkdir -p /elasticsearch/config/scripts /elasticsearch/plugins \
+  && chown -R elasticsearch:elasticsearch /elasticsearch \
   && rm -rf /tmp/* \
   && apk del --purge .build-deps
 


### PR DESCRIPTION
Related to #70 and #71

- Setting ownership of the `/elasticsearch` directory is now part of the
  Dockerfile. Ownership of the `/data` folder is changed only when
  started for the first time.
- The `SHARD_ALLOCATION_AWARENESS_ATTR` environment variable was
  previously required to contain a file path. Now, the environment
  variable can contain the actual value of the node metadata
  attribute. Also, this attribute can be set on any node.